### PR TITLE
Update the iOS version to v9. Also changed the dependency from master…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,12 @@ import PackageDescription
 
 let package = Package(
     name: "MarkdownSyntax",
-    platforms: [.macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)],
+    platforms: [.macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)],
     products: [
         .library(name: "MarkdownSyntax", targets: ["MarkdownSyntax"]),
     ],
     dependencies: [
-        .package(name: "cmark_gfm", url: "https://github.com/hebertialmeida/swift-cmark-gfm", .branch("master"))
+        .package(name: "cmark_gfm", url: "https://github.com/hebertialmeida/swift-cmark-gfm", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(name: "MarkdownSyntax", dependencies: ["cmark_gfm"]),


### PR DESCRIPTION
You may need to add tag 1.0.0 to https://github.com/hebertialmeida/swift-cmark-gfm repository. Then it will pull the dependency using the .upToNextMajor(from: "1.0.0").

Thanks. 